### PR TITLE
perf: replace ahash with gxhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1.10.4"
 lazy_static = "1.4.0"
 counter = "0.5.7"
 rayon = "1.10.0"
-gxhash = "3.0.0"
+gxhash = "=3.0.0"
 
 [dependencies.pyo3]
 version = "0.21.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1.10.4"
 lazy_static = "1.4.0"
 counter = "0.5.7"
 rayon = "1.10.0"
-ahash = "0.8.11"
+gxhash = "3.1.1"
 
 [dependencies.pyo3]
 version = "0.21.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1.10.4"
 lazy_static = "1.4.0"
 counter = "0.5.7"
 rayon = "1.10.0"
-gxhash = "3.1.1"
+gxhash = "3.0.0"
 
 [dependencies.pyo3]
 version = "0.21.1"

--- a/src/bleu.rs
+++ b/src/bleu.rs
@@ -1,6 +1,6 @@
 use crate::ngram::get_token_ngram_counter;
 use crate::tokenizer::{Tokenizer, Tokenizer13a};
-use ahash::AHashMap;
+use gxhash::GxHashMap;
 use rayon::prelude::*;
 use std::cmp::min;
 use std::ops::Add;
@@ -61,7 +61,7 @@ pub fn compute_score(
             }
 
             let translation_ngram_counts = get_token_ngram_counter(&translation_tokens, max_order);
-            let mut merged_ref_ngram_counts = AHashMap::new();
+            let mut merged_ref_ngram_counts = GxHashMap::default();
             for reference_tokens in references_tokens.iter() {
                 let reference_ngram_counts = get_token_ngram_counter(reference_tokens, max_order);
                 for (key, value) in reference_ngram_counts {

--- a/src/ngram.rs
+++ b/src/ngram.rs
@@ -1,10 +1,10 @@
 use counter::Counter;
-use std::collections::HashMap;
+use gxhash::GxHashMap;
 
 /// Here the tokens' type is `&[String]` rather than `&Vec<String>`
 /// to fix `clippy::not_unsafe_ptr_arg_deref` error.
-pub fn get_token_ngram_counter(tokens: &[String], max_order: usize) -> HashMap<&[String], usize> {
-    let mut count_map: HashMap<&[String], usize> = HashMap::new();
+pub fn get_token_ngram_counter(tokens: &[String], max_order: usize) -> GxHashMap<&[String], usize> {
+    let mut count_map: GxHashMap<&[String], usize> = GxHashMap::default();
     for order in 1..=max_order {
         for start_index in 0..(tokens.len().saturating_sub(order - 1)) {
             let ngram = &tokens[start_index..(start_index + order)];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved performance by switching from `AHashMap` to `GxHashMap` for storing ngram counts.
  - Updated internal data structures in key functions to use `GxHashMap` for more efficient memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->