### PR TITLE
Fix docs deploy workflow for pull requests

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: GitHub Pages
@@ -28,6 +31,7 @@ jobs:
           echo "<meta http-equiv=\"refresh\" content=\"0; url=bleuscore\">" > target/doc/index.html
 
       - name: Deploy Docs
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- keep docs builds running on pull requests
- only deploy generated docs to gh-pages on pushes to master
- grant contents write permission for the deployment step

## Why
Dependabot pull requests trigger the docs workflow via pull_request, but the deploy step attempts to push to gh-pages. That fails because pull request tokens do not have the required write permission. Gating deployment to master push events lets PRs validate docs without trying to publish them.

## Testing
- Not run locally; workflow-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment workflow to execute only on commits to the main branch, improving deployment stability and preventing unintended documentation updates from pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->