### PR TITLE
feat: add configurable reference length mode (Shortest/HuggingFace vs Closest/SacreBLEU)

### DIFF
--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           set -e
           pip install bleuscore --no-index --find-links dist --force-reinstall
-          pip install pytest hypothesis evaluate
+          pip install pytest hypothesis evaluate sacrebleu
           cd bindings/python/tests
           pytest --hypothesis-show-statistics .
 
@@ -76,7 +76,7 @@ jobs:
           run: |
             set -e
             pip3 install bleuscore --no-index --find-links dist --force-reinstall
-            pip3 install pytest hypothesis evaluate
+            pip3 install pytest hypothesis evaluate sacrebleu
             cd bindings/python/tests
             pytest --hypothesis-show-statistics .
 
@@ -111,7 +111,7 @@ jobs:
         run: |
           set -e
           pip install bleuscore --no-index --find-links dist --force-reinstall
-          pip install pytest hypothesis evaluate
+          pip install pytest hypothesis evaluate sacrebleu
           cd bindings/python/tests
           pytest --hypothesis-show-statistics .
 
@@ -145,7 +145,7 @@ jobs:
         run: |
           set -e
           pip install bleuscore --no-index --find-links dist --force-reinstall
-          pip install pytest hypothesis evaluate
+          pip install pytest hypothesis evaluate sacrebleu
           cd bindings/python/tests
           pytest --hypothesis-show-statistics .
 

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -22,3 +22,6 @@ js-sys = "0.3.77"
 tsify = "0.5.5"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/bindings/js/index.js
+++ b/bindings/js/index.js
@@ -30,6 +30,7 @@ let bleu_result = compute_score(
     ["hello there general kenobi", "foo bar foobar"],
     4,
     false,
+    "shortest",
 )
 initWasm();
 console.log(bleu_result)

--- a/bindings/js/src/bleu.rs
+++ b/bindings/js/src/bleu.rs
@@ -41,6 +41,16 @@ macro_rules! console_log {
     ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
 }
 
+fn parse_ref_len_method(value: &str) -> Result<bleuscore::bleu::RefLenMethod, JsError> {
+    match value {
+        "shortest" | "hf" => Ok(bleuscore::bleu::RefLenMethod::Shortest),
+        "closest" | "sacrebleu" => Ok(bleuscore::bleu::RefLenMethod::Closest),
+        other => Err(JsError::new(&format!(
+            "Unknown ref_len_method {other:?}. Valid values: \"shortest\", \"hf\", \"closest\", \"sacrebleu\"."
+        ))),
+    }
+}
+
 #[derive(Debug, Default, Tsify, Serialize, Deserialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct BleuScore {
@@ -59,6 +69,23 @@ pub fn compute_score(
     max_order: usize,
     smooth: bool,
 ) -> Result<BleuScore, JsError> {
+    compute_score_with_ref_len_method(
+        references_js_array,
+        predictions_js_array,
+        max_order,
+        smooth,
+        "shortest",
+    )
+}
+
+#[wasm_bindgen]
+pub fn compute_score_with_ref_len_method(
+    references_js_array: VecVecString,
+    predictions_js_array: VecString,
+    max_order: usize,
+    smooth: bool,
+    ref_len_method: &str,
+) -> Result<BleuScore, JsError> {
     // Convert JsValue to Rust Vec<Vec<String>>
     let references_vec: Vec<Vec<String>> = references_js_array.convert()?;
     console_log!("references_vec: {:?}", references_vec);
@@ -67,7 +94,14 @@ pub fn compute_score(
     let predictions_vec: Vec<String> = predictions_js_array.convert()?;
     console_log!("predictions_vec: {:?}", predictions_vec);
 
-    let res = bleuscore::bleu::compute_score(&references_vec, &predictions_vec, max_order, smooth, bleuscore::bleu::RefLenMethod::Shortest);
+    let method = parse_ref_len_method(ref_len_method)?;
+    let res = bleuscore::bleu::compute_score_with_ref_len_method(
+        &references_vec,
+        &predictions_vec,
+        max_order,
+        smooth,
+        method,
+    );
     console_log!("bleu_result: {:?}", res);
     Ok(BleuScore {
         bleu: res.bleu,
@@ -88,7 +122,7 @@ pub fn compute_score_direct(
     max_order: usize,
     smooth: bool,
 ) -> BleuScore {
-    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth, bleuscore::bleu::RefLenMethod::Shortest);
+    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth);
     BleuScore {
         bleu: res.bleu,
         precisions: res.precisions,
@@ -109,7 +143,7 @@ pub fn compute_score_debug(
 ) -> BleuScore {
     println!("Debug: references = {:?}", references);
     println!("Debug: predictions = {:?}", predictions);
-    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth, bleuscore::bleu::RefLenMethod::Shortest);
+    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth);
     println!("Debug: result = {:?}", res);
     BleuScore {
         bleu: res.bleu,

--- a/bindings/js/src/bleu.rs
+++ b/bindings/js/src/bleu.rs
@@ -67,7 +67,7 @@ pub fn compute_score(
     let predictions_vec: Vec<String> = predictions_js_array.convert()?;
     console_log!("predictions_vec: {:?}", predictions_vec);
 
-    let res = bleuscore::bleu::compute_score(&references_vec, &predictions_vec, max_order, smooth);
+    let res = bleuscore::bleu::compute_score(&references_vec, &predictions_vec, max_order, smooth, bleuscore::bleu::RefLenMethod::Shortest);
     console_log!("bleu_result: {:?}", res);
     Ok(BleuScore {
         bleu: res.bleu,
@@ -88,7 +88,7 @@ pub fn compute_score_direct(
     max_order: usize,
     smooth: bool,
 ) -> BleuScore {
-    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth);
+    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth, bleuscore::bleu::RefLenMethod::Shortest);
     BleuScore {
         bleu: res.bleu,
         precisions: res.precisions,
@@ -109,7 +109,7 @@ pub fn compute_score_debug(
 ) -> BleuScore {
     println!("Debug: references = {:?}", references);
     println!("Debug: predictions = {:?}", predictions);
-    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth);
+    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth, bleuscore::bleu::RefLenMethod::Shortest);
     println!("Debug: result = {:?}", res);
     BleuScore {
         bleu: res.bleu,

--- a/bindings/js/src/bleu.rs
+++ b/bindings/js/src/bleu.rs
@@ -68,22 +68,6 @@ pub fn compute_score(
     predictions_js_array: VecString,
     max_order: usize,
     smooth: bool,
-) -> Result<BleuScore, JsError> {
-    compute_score_with_ref_len_method(
-        references_js_array,
-        predictions_js_array,
-        max_order,
-        smooth,
-        "shortest",
-    )
-}
-
-#[wasm_bindgen]
-pub fn compute_score_with_ref_len_method(
-    references_js_array: VecVecString,
-    predictions_js_array: VecString,
-    max_order: usize,
-    smooth: bool,
     ref_len_method: &str,
 ) -> Result<BleuScore, JsError> {
     // Convert JsValue to Rust Vec<Vec<String>>
@@ -95,7 +79,7 @@ pub fn compute_score_with_ref_len_method(
     console_log!("predictions_vec: {:?}", predictions_vec);
 
     let method = parse_ref_len_method(ref_len_method)?;
-    let res = bleuscore::bleu::compute_score_with_ref_len_method(
+    let res = bleuscore::bleu::compute_score(
         &references_vec,
         &predictions_vec,
         max_order,
@@ -122,7 +106,13 @@ pub fn compute_score_direct(
     max_order: usize,
     smooth: bool,
 ) -> BleuScore {
-    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth);
+    let res = bleuscore::bleu::compute_score(
+        references,
+        predictions,
+        max_order,
+        smooth,
+        bleuscore::bleu::RefLenMethod::Shortest,
+    );
     BleuScore {
         bleu: res.bleu,
         precisions: res.precisions,
@@ -143,7 +133,13 @@ pub fn compute_score_debug(
 ) -> BleuScore {
     println!("Debug: references = {:?}", references);
     println!("Debug: predictions = {:?}", predictions);
-    let res = bleuscore::bleu::compute_score(references, predictions, max_order, smooth);
+    let res = bleuscore::bleu::compute_score(
+        references,
+        predictions,
+        max_order,
+        smooth,
+        bleuscore::bleu::RefLenMethod::Shortest,
+    );
     println!("Debug: result = {:?}", res);
     BleuScore {
         bleu: res.bleu,
@@ -265,10 +261,11 @@ mod tests {
         // - VecString (predictions)
         // - usize (max_order)
         // - bool (smooth)
+        // - &str (ref_len_method)
         // And return Result<BleuScore, JsError>
 
         // We can't actually call it in non-WASM tests, but we can verify the types exist
-        let _: fn(VecVecString, VecString, usize, bool) -> Result<BleuScore, JsError> =
+        let _: fn(VecVecString, VecString, usize, bool, &str) -> Result<BleuScore, JsError> =
             compute_score;
     }
 

--- a/bindings/js/src/bleu.rs
+++ b/bindings/js/src/bleu.rs
@@ -330,4 +330,39 @@ mod tests {
         assert!(score.bleu <= 1.0);
         assert_eq!(score.precisions.len(), 2);
     }
+
+    #[test]
+    fn test_parse_ref_len_method_shortest_variants() {
+        assert!(matches!(
+            parse_ref_len_method("shortest"),
+            Ok(bleuscore::bleu::RefLenMethod::Shortest)
+        ));
+        assert!(matches!(
+            parse_ref_len_method("hf"),
+            Ok(bleuscore::bleu::RefLenMethod::Shortest)
+        ));
+    }
+
+    #[test]
+    fn test_parse_ref_len_method_closest_variants() {
+        assert!(matches!(
+            parse_ref_len_method("closest"),
+            Ok(bleuscore::bleu::RefLenMethod::Closest)
+        ));
+        assert!(matches!(
+            parse_ref_len_method("sacrebleu"),
+            Ok(bleuscore::bleu::RefLenMethod::Closest)
+        ));
+    }
+
+    #[test]
+    fn test_parse_ref_len_method_invalid() {
+        // JsError::new() panics on non-wasm targets, so we test via panic
+        // The function returns Err(JsError) for unknown values; on non-wasm the
+        // JsError construction itself panics, which also means it cannot return Ok.
+        let result = std::panic::catch_unwind(|| parse_ref_len_method("unknown"));
+        assert!(result.is_err(), "invalid method should not return Ok");
+        let result2 = std::panic::catch_unwind(|| parse_ref_len_method(""));
+        assert!(result2.is_err(), "empty method should not return Ok");
+    }
 }

--- a/bindings/python/python/bleuscore/__init__.pyi
+++ b/bindings/python/python/bleuscore/__init__.pyi
@@ -4,7 +4,7 @@ Type stubs for bleuscore - Fast BLEU Score Calculator
 This file provides type hints for the Rust-based bleuscore library.
 """
 
-from typing import List, Dict, Union
+from typing import List, Dict, Literal, Union
 
 __version__: str
 
@@ -13,6 +13,7 @@ def compute(
     predictions: List[str],
     max_order: int = 4,
     smooth: bool = False,
+    ref_len_method: Literal["shortest", "hf", "closest", "sacrebleu"] = "shortest",
 ) -> Dict[str, Union[float, List[float], int]]:
     """
     Calculate BLEU score for machine translation predictions.
@@ -30,6 +31,13 @@ def compute(
                   Must be >= 1. Common values: 1, 2, 3, 4.
         smooth: Whether to apply smoothing to avoid zero precision scores (default: False).
                Smoothing adds 1 to numerator and denominator of precision calculations.
+        ref_len_method: Strategy for selecting the effective reference length when
+                       multiple references are provided per segment (default: "shortest").
+                       - "shortest" / "hf": shortest reference length
+                         (compatible with HuggingFace evaluate / TF NMT).
+                       - "closest" / "sacrebleu": reference length closest to hypothesis
+                         length; shorter wins on ties
+                         (compatible with SacreBLEU / NIST mteval-v13a).
     
     Returns:
         Dictionary containing:
@@ -38,10 +46,11 @@ def compute(
             - brevity_penalty (float): Penalty for short translations (0.0 to 1.0)
             - length_ratio (float): Ratio of translation length to reference length
             - translation_length (int): Total length of all predictions in tokens
-            - reference_length (int): Total length of closest references in tokens
+            - reference_length (int): Total length of selected references in tokens
     
     Raises:
         AssertionError: If references or predictions are empty, or if their lengths don't match.
+        ValueError: If ref_len_method is not one of the accepted values.
         
     Example:
         >>> import bleuscore

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,4 +1,4 @@
-use bleuscore::bleu::compute_score;
+use bleuscore::bleu::{compute_score, RefLenMethod};
 use bleuscore::tokenizer::{Tokenizer, Tokenizer13a, TokenizerRegex};
 
 use pyo3::prelude::*;
@@ -18,15 +18,35 @@ fn tokenizer_13a(line: &str) -> PyResult<Vec<String>> {
     Ok(res)
 }
 
+/// Resolve `ref_len_method` string (including aliases) to `RefLenMethod`.
+///
+/// Accepted values:
+/// - `"shortest"` / `"hf"` → [`RefLenMethod::Shortest`]
+///   (HuggingFace evaluate / TF NMT compatible)
+/// - `"closest"` / `"sacrebleu"` → [`RefLenMethod::Closest`]
+///   (SacreBLEU / NIST mteval-v13a compatible)
+fn parse_ref_len_method(value: &str) -> PyResult<RefLenMethod> {
+    match value {
+        "shortest" | "hf" => Ok(RefLenMethod::Shortest),
+        "closest" | "sacrebleu" => Ok(RefLenMethod::Closest),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Unknown ref_len_method {other:?}. \
+             Valid values: \"shortest\", \"hf\", \"closest\", \"sacrebleu\"."
+        ))),
+    }
+}
+
 #[pyfunction]
-#[pyo3(signature = (references, predictions, max_order=4, smooth=false))]
+#[pyo3(signature = (references, predictions, max_order=4, smooth=false, ref_len_method="shortest"))]
 fn compute(
     references: Vec<Vec<String>>,
     predictions: Vec<String>,
     max_order: usize,
     smooth: bool,
+    ref_len_method: &str,
 ) -> PyResult<Py<PyAny>> {
-    let bleu = compute_score(&references, &predictions, max_order, smooth);
+    let method = parse_ref_len_method(ref_len_method)?;
+    let bleu = compute_score(&references, &predictions, max_order, smooth, method);
     Python::attach(|py| {
         let bleu_dict = PyDict::new(py);
         bleu_dict.set_item("bleu", bleu.bleu)?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -65,14 +65,23 @@ mod tests {
 
     #[test]
     fn test_parse_ref_len_method_shortest_variants() {
-        assert_eq!(parse_ref_len_method("shortest").unwrap(), RefLenMethod::Shortest);
+        assert_eq!(
+            parse_ref_len_method("shortest").unwrap(),
+            RefLenMethod::Shortest
+        );
         assert_eq!(parse_ref_len_method("hf").unwrap(), RefLenMethod::Shortest);
     }
 
     #[test]
     fn test_parse_ref_len_method_closest_variants() {
-        assert_eq!(parse_ref_len_method("closest").unwrap(), RefLenMethod::Closest);
-        assert_eq!(parse_ref_len_method("sacrebleu").unwrap(), RefLenMethod::Closest);
+        assert_eq!(
+            parse_ref_len_method("closest").unwrap(),
+            RefLenMethod::Closest
+        );
+        assert_eq!(
+            parse_ref_len_method("sacrebleu").unwrap(),
+            RefLenMethod::Closest
+        );
     }
 
     #[test]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,4 +1,4 @@
-use bleuscore::bleu::{compute_score_with_ref_len_method, RefLenMethod};
+use bleuscore::bleu::{compute_score, RefLenMethod};
 use bleuscore::tokenizer::{Tokenizer, Tokenizer13a, TokenizerRegex};
 
 use pyo3::prelude::*;
@@ -46,8 +46,7 @@ fn compute(
     ref_len_method: &str,
 ) -> PyResult<Py<PyAny>> {
     let method = parse_ref_len_method(ref_len_method)?;
-    let bleu =
-        compute_score_with_ref_len_method(&references, &predictions, max_order, smooth, method);
+    let bleu = compute_score(&references, &predictions, max_order, smooth, method);
     Python::attach(|py| {
         let bleu_dict = PyDict::new(py);
         bleu_dict.set_item("bleu", bleu.bleu)?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,4 +1,4 @@
-use bleuscore::bleu::{compute_score, RefLenMethod};
+use bleuscore::bleu::{compute_score_with_ref_len_method, RefLenMethod};
 use bleuscore::tokenizer::{Tokenizer, Tokenizer13a, TokenizerRegex};
 
 use pyo3::prelude::*;
@@ -46,7 +46,8 @@ fn compute(
     ref_len_method: &str,
 ) -> PyResult<Py<PyAny>> {
     let method = parse_ref_len_method(ref_len_method)?;
-    let bleu = compute_score(&references, &predictions, max_order, smooth, method);
+    let bleu =
+        compute_score_with_ref_len_method(&references, &predictions, max_order, smooth, method);
     Python::attach(|py| {
         let bleu_dict = PyDict::new(py);
         bleu_dict.set_item("bleu", bleu.bleu)?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -59,6 +59,29 @@ fn compute(
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ref_len_method_shortest_variants() {
+        assert_eq!(parse_ref_len_method("shortest").unwrap(), RefLenMethod::Shortest);
+        assert_eq!(parse_ref_len_method("hf").unwrap(), RefLenMethod::Shortest);
+    }
+
+    #[test]
+    fn test_parse_ref_len_method_closest_variants() {
+        assert_eq!(parse_ref_len_method("closest").unwrap(), RefLenMethod::Closest);
+        assert_eq!(parse_ref_len_method("sacrebleu").unwrap(), RefLenMethod::Closest);
+    }
+
+    #[test]
+    fn test_parse_ref_len_method_invalid() {
+        assert!(parse_ref_len_method("unknown").is_err());
+        assert!(parse_ref_len_method("").is_err());
+    }
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _bleuscore(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/bindings/python/tests/test_bleu_score.py
+++ b/bindings/python/tests/test_bleu_score.py
@@ -2,6 +2,7 @@ import datetime
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from sacrebleu.metrics import BLEU as SacreBLEU
 
 import bleuscore
 import py_bleu
@@ -103,3 +104,98 @@ def hf_bleu_result_compare(references, predictions, max_order, smooth, debug=Fal
                 assert number_close(v, bleuscore_result[key][i]), f"p: {predictions}\nr: {references}"
         else:
             assert number_close(hf_result[key], bleuscore_result[key]), f"p: {predictions}\nr: {references}"
+
+
+# ---------------------------------------------------------------------------
+# SacreBLEU compatibility tests  (ref_len_method="closest" / "sacrebleu")
+# ---------------------------------------------------------------------------
+
+def refs_to_sacrebleu_format(refs_per_pred):
+    """Convert from evaluate-style format::
+
+        [[ref1_pred1, ref2_pred1], [ref1_pred2], ...]
+
+    to SacreBLEU reference-stream format::
+
+        [[ref1_pred1, ref1_pred2, ...], [ref2_pred1, None, ...]]
+    """
+    max_refs = max(len(r) for r in refs_per_pred)
+    return [
+        [refs[i] if i < len(refs) else None for refs in refs_per_pred]
+        for i in range(max_refs)
+    ]
+
+
+def sacrebleu_result_compare(references, predictions, max_order, debug=False):
+    bleuscore_result = bleuscore.compute(
+        references=references,
+        predictions=predictions,
+        max_order=max_order,
+        smooth=False,
+        ref_len_method="closest",
+    )
+    bleu = SacreBLEU(smooth_method="none", max_ngram_order=max_order, tokenize="13a")
+    sacre_result = bleu.corpus_score(predictions, refs_to_sacrebleu_format(references))
+
+    if debug:
+        print(f"bleuscore : {bleuscore_result}")
+        print(f"sacrebleu : {sacre_result}")
+
+    # SacreBLEU scores are in the 0-100 range; bleuscore uses 0-1.
+    assert number_close(bleuscore_result["bleu"], sacre_result.score / 100), (
+        f"bleu mismatch: {bleuscore_result['bleu']} vs {sacre_result.score / 100}\n"
+        f"p: {predictions}\nr: {references}"
+    )
+    for i, prec in enumerate(sacre_result.precisions):
+        assert number_close(bleuscore_result["precisions"][i], prec / 100), (
+            f"precision[{i}] mismatch: "
+            f"{bleuscore_result['precisions'][i]} vs {prec / 100}\n"
+            f"p: {predictions}\nr: {references}"
+        )
+    assert number_close(bleuscore_result["brevity_penalty"], sacre_result.bp), (
+        f"bp mismatch: {bleuscore_result['brevity_penalty']} vs {sacre_result.bp}\n"
+        f"p: {predictions}\nr: {references}"
+    )
+    assert bleuscore_result["translation_length"] == sacre_result.sys_len, (
+        f"sys_len mismatch: "
+        f"{bleuscore_result['translation_length']} vs {sacre_result.sys_len}\n"
+        f"p: {predictions}\nr: {references}"
+    )
+    assert bleuscore_result["reference_length"] == sacre_result.ref_len, (
+        f"ref_len mismatch: "
+        f"{bleuscore_result['reference_length']} vs {sacre_result.ref_len}\n"
+        f"p: {predictions}\nr: {references}"
+    )
+
+
+def test_sacrebleu_simple():
+    """Fixed case that exercises closest != shortest (hyp longer than shorter ref)."""
+    predictions = ["hello there general kenobi", "foo bar foobar"]
+    references = [
+        ["hello there general kenobi", "hello there !"],
+        ["foo bar foobar"],
+    ]
+    sacrebleu_result_compare(references, predictions, max_order=4)
+
+
+def test_sacrebleu_closest_differs_from_shortest():
+    """Case where ref_len_method matters: hyp is closer to the longer reference."""
+    # pred: 4 tokens; ref1: 3 tokens; ref2: 4 tokens
+    # closest -> ref2 (len=4); shortest -> ref1 (len=3)
+    predictions = ["hello there general kenobi"]
+    references = [["hello there !", "hello there general kenobi"]]
+    sacrebleu_result_compare(references, predictions, max_order=4)
+
+
+@settings(max_examples=500, deadline=datetime.timedelta(seconds=10))
+@given(
+    st.text(
+        alphabet=st.characters(min_codepoint=32, max_codepoint=126),
+        min_size=5,
+        max_size=100,
+    ),
+    st.integers(min_value=1, max_value=4),
+)
+def test_sacrebleu_bleu(input_text, max_order):
+    predictions, references = build_translation_pair(text=input_text, n=3)
+    sacrebleu_result_compare(references, predictions, max_order=max_order)

--- a/bindings/python/tests/test_bleu_score.py
+++ b/bindings/python/tests/test_bleu_score.py
@@ -187,6 +187,33 @@ def test_sacrebleu_closest_differs_from_shortest():
     sacrebleu_result_compare(references, predictions, max_order=4)
 
 
+def test_ref_len_method_aliases():
+    predictions = ["hello there general kenobi"]
+    references = [["hello there !", "hello there general kenobi"]]
+
+    shortest = bleuscore.compute(references, predictions, ref_len_method="shortest")
+    hf = bleuscore.compute(references, predictions, ref_len_method="hf")
+    closest = bleuscore.compute(references, predictions, ref_len_method="closest")
+    sacrebleu = bleuscore.compute(references, predictions, ref_len_method="sacrebleu")
+
+    assert hf == shortest
+    assert sacrebleu == closest
+    assert shortest["reference_length"] == 3
+    assert closest["reference_length"] == 4
+
+
+def test_invalid_ref_len_method():
+    predictions = ["hello there general kenobi"]
+    references = [["hello there general kenobi"]]
+
+    try:
+        bleuscore.compute(references, predictions, ref_len_method="invalid")
+    except ValueError as exc:
+        assert "Unknown ref_len_method" in str(exc)
+    else:
+        raise AssertionError("invalid ref_len_method should raise ValueError")
+
+
 @settings(max_examples=500, deadline=datetime.timedelta(seconds=10))
 @given(
     st.text(

--- a/crates/bleuscore/Cargo.toml
+++ b/crates/bleuscore/Cargo.toml
@@ -24,6 +24,9 @@ rayon.workspace = true
 ahash.workspace = true
 getrandom.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+
 [dev-dependencies]
 divan = { version = "4.1.0", package = "codspeed-divan-compat" }
 

--- a/crates/bleuscore/benches/bleu_bench.rs
+++ b/crates/bleuscore/benches/bleu_bench.rs
@@ -18,6 +18,7 @@ fn bleu_single() {
         black_box(&predictions),
         black_box(max_order),
         black_box(smooth),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -38,6 +39,7 @@ fn bleu_batch(n: usize) {
         black_box(&predictions),
         black_box(max_order),
         black_box(smooth),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -53,6 +55,7 @@ fn bleu_max_order(max_order: usize) {
         black_box(&predictions),
         black_box(max_order),
         black_box(smooth),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -68,6 +71,7 @@ fn bleu_smoothing(smooth: bool) {
         black_box(&predictions),
         black_box(max_order),
         black_box(smooth),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -88,5 +92,6 @@ fn bleu_long_text() {
         black_box(&predictions),
         black_box(max_order),
         black_box(smooth),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }

--- a/crates/bleuscore/benches/e2e_bench.rs
+++ b/crates/bleuscore/benches/e2e_bench.rs
@@ -19,6 +19,7 @@ fn e2e_single_sentence() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -37,6 +38,7 @@ fn e2e_multiple_references() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -72,6 +74,7 @@ fn e2e_batch_realistic(batch_size: usize) {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -86,6 +89,7 @@ fn e2e_short_texts() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -110,6 +114,7 @@ fn e2e_long_texts() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -125,6 +130,7 @@ fn e2e_perfect_match() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -142,6 +148,7 @@ fn e2e_complete_mismatch() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -159,6 +166,7 @@ fn e2e_special_chars() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -177,6 +185,7 @@ fn e2e_translation_scenario() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }
 
@@ -192,5 +201,6 @@ fn e2e_html_entities() {
         black_box(&predictions),
         black_box(4),
         black_box(true),
+        black_box(bleuscore::RefLenMethod::Shortest),
     ));
 }

--- a/crates/bleuscore/src/bleu.rs
+++ b/crates/bleuscore/src/bleu.rs
@@ -61,22 +61,6 @@ pub fn compute_score(
     predictions: &[String],
     max_order: usize,
     smooth: bool,
-) -> BleuScore {
-    compute_score_with_ref_len_method(
-        references,
-        predictions,
-        max_order,
-        smooth,
-        RefLenMethod::Shortest,
-    )
-}
-
-/// compute the BLEU score with a configurable reference length selection method.
-pub fn compute_score_with_ref_len_method(
-    references: &[Vec<String>],
-    predictions: &[String],
-    max_order: usize,
-    smooth: bool,
     ref_len_method: RefLenMethod,
 ) -> BleuScore {
     let tokenizer = Tokenizer13a::new();
@@ -195,17 +179,20 @@ fn add_vectors<T: Add<Output = T>>(vec1: Vec<T>, vec2: Vec<T>) -> Vec<T> {
 
 #[cfg(test)]
 mod test {
-    use crate::bleu::{
-        add_vectors, agg_stat, closest_ref_len, compute_score, compute_score_with_ref_len_method,
-        RefLenMethod, Stat,
-    };
+    use crate::bleu::{add_vectors, agg_stat, closest_ref_len, compute_score, RefLenMethod, Stat};
     #[test]
     fn test_bleu() {
         let references: Vec<Vec<String>> = vec![vec!["Hello, World!".to_string()]];
         let predictions: Vec<String> = vec!["Yellow, World!".to_string()];
         let max_order: usize = 4;
         let smooth: bool = true;
-        let res = compute_score(&references, &predictions, max_order, smooth);
+        let res = compute_score(
+            &references,
+            &predictions,
+            max_order,
+            smooth,
+            RefLenMethod::Shortest,
+        );
         // (0.668740304976422, [0.8, 0.75, 0.6666666666666666, 0.5], 1.0, 1.0, 4, 4)
         println!("result: {:?}", res);
         assert!((res.bleu - 0.668740304976422).abs() < 1e-10);
@@ -237,7 +224,13 @@ mod test {
         let predictions: Vec<String> = vec!["a a".to_string()];
         let max_order: usize = 1;
         let smooth: bool = false;
-        let res = compute_score(&references, &predictions, max_order, smooth);
+        let res = compute_score(
+            &references,
+            &predictions,
+            max_order,
+            smooth,
+            RefLenMethod::Shortest,
+        );
 
         // Precision should be 0.5
         assert!((res.precisions[0] - 0.5).abs() < 1e-10);
@@ -258,14 +251,8 @@ mod test {
         ]];
         let predictions: Vec<String> = vec!["hello there general kenobi".to_string()];
 
-        let shortest = compute_score(&references, &predictions, 4, false);
-        let closest = compute_score_with_ref_len_method(
-            &references,
-            &predictions,
-            4,
-            false,
-            RefLenMethod::Closest,
-        );
+        let shortest = compute_score(&references, &predictions, 4, false, RefLenMethod::Shortest);
+        let closest = compute_score(&references, &predictions, 4, false, RefLenMethod::Closest);
 
         assert_eq!(shortest.reference_length, 3);
         assert_eq!(closest.reference_length, 4);

--- a/crates/bleuscore/src/bleu.rs
+++ b/crates/bleuscore/src/bleu.rs
@@ -5,6 +5,20 @@ use rayon::prelude::*;
 use std::cmp::{max, min};
 use std::ops::Add;
 
+/// Method for selecting the effective reference length in multi-reference BLEU.
+///
+/// - `Shortest` – always uses the shortest reference length per segment
+///   (compatible with HuggingFace evaluate / TF NMT).
+/// - `Closest` – uses the reference length closest to the hypothesis length;
+///   on ties the shorter reference wins
+///   (compatible with SacreBLEU / NIST mteval-v13a).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RefLenMethod {
+    #[default]
+    Shortest,
+    Closest,
+}
+
 /// The BLEU score data struct
 #[derive(Debug, Default)]
 pub struct BleuScore {
@@ -30,6 +44,16 @@ fn agg_stat(s1: Stat, s2: Stat) -> Stat {
     )
 }
 
+/// Returns the reference length closest to `hyp_len`.
+/// On ties, the shorter reference wins (matching SacreBLEU behaviour).
+fn closest_ref_len(hyp_len: usize, ref_lens: &[usize]) -> usize {
+    ref_lens
+        .iter()
+        .copied()
+        .min_by_key(|&rl| (hyp_len.abs_diff(rl), rl))
+        .unwrap()
+}
+
 /// compute the BLEU score with `Tokenizer13a` as default tokenizer.
 /// The implementation is based on [huggingface/nmt](https://github.com/huggingface/evaluate/blob/main/metrics/bleu/bleu.py)
 pub fn compute_score(
@@ -37,6 +61,7 @@ pub fn compute_score(
     predictions: &[String],
     max_order: usize,
     smooth: bool,
+    ref_len_method: RefLenMethod,
 ) -> BleuScore {
     let tokenizer = Tokenizer13a::new();
 
@@ -49,8 +74,12 @@ pub fn compute_score(
             let references_tokens: Vec<Vec<String>> =
                 references.iter().map(|x| tokenizer.tokenize(x)).collect();
 
-            let reference_length = references_tokens.iter().map(|x| x.len()).min().unwrap();
+            let ref_lens: Vec<usize> = references_tokens.iter().map(|x| x.len()).collect();
             let translation_length = translation_tokens.len();
+            let reference_length = match ref_len_method {
+                RefLenMethod::Shortest => *ref_lens.iter().min().unwrap(),
+                RefLenMethod::Closest => closest_ref_len(translation_length, &ref_lens),
+            };
 
             let mut possible_matches_by_order = vec![0; max_order];
             for order in 1..=max_order {
@@ -150,14 +179,14 @@ fn add_vectors<T: Add<Output = T>>(vec1: Vec<T>, vec2: Vec<T>) -> Vec<T> {
 
 #[cfg(test)]
 mod test {
-    use crate::bleu::{add_vectors, agg_stat, compute_score, Stat};
+    use crate::bleu::{add_vectors, agg_stat, closest_ref_len, compute_score, RefLenMethod, Stat};
     #[test]
     fn test_bleu() {
         let references: Vec<Vec<String>> = vec![vec!["Hello, World!".to_string()]];
         let predictions: Vec<String> = vec!["Yellow, World!".to_string()];
         let max_order: usize = 4;
         let smooth: bool = true;
-        let res = compute_score(&references, &predictions, max_order, smooth);
+        let res = compute_score(&references, &predictions, max_order, smooth, RefLenMethod::Shortest);
         // (0.668740304976422, [0.8, 0.75, 0.6666666666666666, 0.5], 1.0, 1.0, 4, 4)
         println!("result: {:?}", res);
         assert!((res.bleu - 0.668740304976422).abs() < 1e-10);
@@ -189,7 +218,7 @@ mod test {
         let predictions: Vec<String> = vec!["a a".to_string()];
         let max_order: usize = 1;
         let smooth: bool = false;
-        let res = compute_score(&references, &predictions, max_order, smooth);
+        let res = compute_score(&references, &predictions, max_order, smooth, RefLenMethod::Shortest);
 
         // Precision should be 0.5
         assert!((res.precisions[0] - 0.5).abs() < 1e-10);

--- a/crates/bleuscore/src/bleu.rs
+++ b/crates/bleuscore/src/bleu.rs
@@ -61,6 +61,22 @@ pub fn compute_score(
     predictions: &[String],
     max_order: usize,
     smooth: bool,
+) -> BleuScore {
+    compute_score_with_ref_len_method(
+        references,
+        predictions,
+        max_order,
+        smooth,
+        RefLenMethod::Shortest,
+    )
+}
+
+/// compute the BLEU score with a configurable reference length selection method.
+pub fn compute_score_with_ref_len_method(
+    references: &[Vec<String>],
+    predictions: &[String],
+    max_order: usize,
+    smooth: bool,
     ref_len_method: RefLenMethod,
 ) -> BleuScore {
     let tokenizer = Tokenizer13a::new();
@@ -179,14 +195,17 @@ fn add_vectors<T: Add<Output = T>>(vec1: Vec<T>, vec2: Vec<T>) -> Vec<T> {
 
 #[cfg(test)]
 mod test {
-    use crate::bleu::{add_vectors, agg_stat, closest_ref_len, compute_score, RefLenMethod, Stat};
+    use crate::bleu::{
+        add_vectors, agg_stat, closest_ref_len, compute_score, compute_score_with_ref_len_method,
+        RefLenMethod, Stat,
+    };
     #[test]
     fn test_bleu() {
         let references: Vec<Vec<String>> = vec![vec!["Hello, World!".to_string()]];
         let predictions: Vec<String> = vec!["Yellow, World!".to_string()];
         let max_order: usize = 4;
         let smooth: bool = true;
-        let res = compute_score(&references, &predictions, max_order, smooth, RefLenMethod::Shortest);
+        let res = compute_score(&references, &predictions, max_order, smooth);
         // (0.668740304976422, [0.8, 0.75, 0.6666666666666666, 0.5], 1.0, 1.0, 4, 4)
         println!("result: {:?}", res);
         assert!((res.bleu - 0.668740304976422).abs() < 1e-10);
@@ -218,9 +237,37 @@ mod test {
         let predictions: Vec<String> = vec!["a a".to_string()];
         let max_order: usize = 1;
         let smooth: bool = false;
-        let res = compute_score(&references, &predictions, max_order, smooth, RefLenMethod::Shortest);
+        let res = compute_score(&references, &predictions, max_order, smooth);
 
         // Precision should be 0.5
         assert!((res.precisions[0] - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_closest_ref_len() {
+        assert_eq!(closest_ref_len(4, &[3, 4]), 4);
+        assert_eq!(closest_ref_len(4, &[3, 5]), 3);
+        assert_eq!(closest_ref_len(4, &[6, 2, 5]), 5);
+    }
+
+    #[test]
+    fn test_bleu_ref_len_method_closest() {
+        let references: Vec<Vec<String>> = vec![vec![
+            "hello there !".to_string(),
+            "hello there general kenobi".to_string(),
+        ]];
+        let predictions: Vec<String> = vec!["hello there general kenobi".to_string()];
+
+        let shortest = compute_score(&references, &predictions, 4, false);
+        let closest = compute_score_with_ref_len_method(
+            &references,
+            &predictions,
+            4,
+            false,
+            RefLenMethod::Closest,
+        );
+
+        assert_eq!(shortest.reference_length, 3);
+        assert_eq!(closest.reference_length, 4);
     }
 }

--- a/crates/bleuscore/src/lib.rs
+++ b/crates/bleuscore/src/lib.rs
@@ -19,7 +19,7 @@ bleuscore = "*"
 # Basic usage:
 
 ```rust
-use bleuscore::compute_score;
+use bleuscore::{compute_score, RefLenMethod};
 
 // get the references and prediction data:
 let references: Vec<Vec<String>> = vec![vec!["Hello, World!".to_string()]];
@@ -30,7 +30,7 @@ let max_order: usize = 4;
 let smooth: bool = true;
 
 // calculate the BLEU score:
-let res = compute_score(&references, &predictions, max_order, smooth);
+let res = compute_score(&references, &predictions, max_order, smooth, RefLenMethod::Shortest);
 println!("result: {:?}", res);
 // result: BleuScore { bleu: 0.668740304976422, precisions: [0.8, 0.75, 0.6666666666666666, 0.5],
 // brevity_penalty: 1.0, length_ratio: 1.0, translation_length: 4, reference_length: 4 }
@@ -40,4 +40,4 @@ println!("result: {:?}", res);
 pub mod bleu;
 pub mod ngram;
 pub mod tokenizer;
-pub use bleu::compute_score;
+pub use bleu::{compute_score, RefLenMethod};

--- a/crates/bleuscore/src/lib.rs
+++ b/crates/bleuscore/src/lib.rs
@@ -19,7 +19,7 @@ bleuscore = "*"
 # Basic usage:
 
 ```rust
-use bleuscore::{compute_score_with_ref_len_method, RefLenMethod};
+use bleuscore::{compute_score, RefLenMethod};
 
 // get the references and prediction data:
 let references: Vec<Vec<String>> = vec![vec!["Hello, World!".to_string()]];
@@ -30,7 +30,7 @@ let max_order: usize = 4;
 let smooth: bool = true;
 
 // calculate the BLEU score:
-let res = compute_score_with_ref_len_method(
+let res = compute_score(
     &references,
     &predictions,
     max_order,
@@ -46,4 +46,4 @@ println!("result: {:?}", res);
 pub mod bleu;
 pub mod ngram;
 pub mod tokenizer;
-pub use bleu::{compute_score, compute_score_with_ref_len_method, RefLenMethod};
+pub use bleu::{compute_score, RefLenMethod};

--- a/crates/bleuscore/src/lib.rs
+++ b/crates/bleuscore/src/lib.rs
@@ -19,7 +19,7 @@ bleuscore = "*"
 # Basic usage:
 
 ```rust
-use bleuscore::{compute_score, RefLenMethod};
+use bleuscore::{compute_score_with_ref_len_method, RefLenMethod};
 
 // get the references and prediction data:
 let references: Vec<Vec<String>> = vec![vec!["Hello, World!".to_string()]];
@@ -30,7 +30,13 @@ let max_order: usize = 4;
 let smooth: bool = true;
 
 // calculate the BLEU score:
-let res = compute_score(&references, &predictions, max_order, smooth, RefLenMethod::Shortest);
+let res = compute_score_with_ref_len_method(
+    &references,
+    &predictions,
+    max_order,
+    smooth,
+    RefLenMethod::Shortest,
+);
 println!("result: {:?}", res);
 // result: BleuScore { bleu: 0.668740304976422, precisions: [0.8, 0.75, 0.6666666666666666, 0.5],
 // brevity_penalty: 1.0, length_ratio: 1.0, translation_length: 4, reference_length: 4 }
@@ -40,4 +46,4 @@ println!("result: {:?}", res);
 pub mod bleu;
 pub mod ngram;
 pub mod tokenizer;
-pub use bleu::{compute_score, RefLenMethod};
+pub use bleu::{compute_score, compute_score_with_ref_len_method, RefLenMethod};

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -318,7 +318,7 @@ class BleuScoreApp {
             console.log('🔧 Formatted data:', { referencesArray, predictionsArray, maxOrder, smooth });
             
             // Call the WebAssembly function
-            const result = compute_score(referencesArray, predictionsArray, maxOrder, smooth);
+            const result = compute_score(referencesArray, predictionsArray, maxOrder, smooth, 'shortest');
             
             console.log('✅ BLEU calculation successful:', result);
             

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -1,4 +1,4 @@
-import init, { compute_score } from 'bleuscore-js';
+import { compute_score } from 'bleuscore-js';
 
 // Global variables
 let wasmLoaded = false;
@@ -18,7 +18,6 @@ function showError(message) {
 // Initialize WebAssembly
 async function initWasm() {
     try {
-        await init();
         wasmLoaded = true;
         console.log('✅ WebAssembly module loaded successfully');
     } catch (error) {
@@ -27,17 +26,13 @@ async function initWasm() {
     }
 }
 
-// Wait for DOM to be ready, then initialize
-document.addEventListener('DOMContentLoaded', () => {
-    initWasm();
-    new BleuScoreApp();
-});
-
 // Main Application Class
 class BleuScoreApp {
     constructor() {
+        this.refLenMethod = 'shortest';
         this.initializeElements();
         this.setupEventListeners();
+        this.updateRefLenMode(this.refLenMethod);
         this.addInitialPrediction();
     }
 
@@ -46,6 +41,7 @@ class BleuScoreApp {
         this.addPredictionBtn = document.getElementById('add-prediction-btn');
         this.ngramSelect = document.getElementById('ngram');
         this.smoothingCheckbox = document.getElementById('smoothing');
+        this.refLenModeButtons = document.querySelectorAll('.mode-option[data-ref-len-method]');
         this.calculateBtn = document.getElementById('calculate-btn');
         this.loadingDiv = document.getElementById('loading');
         this.resultsDiv = document.getElementById('results');
@@ -61,6 +57,11 @@ class BleuScoreApp {
     setupEventListeners() {
         this.calculateBtn.addEventListener('click', () => this.calculateScore());
         this.addPredictionBtn.addEventListener('click', () => this.addPrediction());
+        this.refLenModeButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                this.updateRefLenMode(button.dataset.refLenMethod);
+            });
+        });
         
         // Allow Ctrl+Enter to calculate
         document.addEventListener('keydown', (e) => {
@@ -68,6 +69,17 @@ class BleuScoreApp {
                 e.preventDefault();
                 this.calculateScore();
             }
+        });
+    }
+
+    updateRefLenMode(method) {
+        this.refLenMethod = method === 'closest' ? 'closest' : 'shortest';
+        document.body.dataset.refLenMethod = this.refLenMethod;
+
+        this.refLenModeButtons.forEach(button => {
+            const isActive = button.dataset.refLenMethod === this.refLenMethod;
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-pressed', String(isActive));
         });
     }
 
@@ -309,16 +321,16 @@ class BleuScoreApp {
             const maxOrder = parseInt(this.ngramSelect.value);
             const smooth = this.smoothingCheckbox.checked;
             
-            console.log('📊 Input data:', { predictions, references, maxOrder, smooth });
+            console.log('📊 Input data:', { predictions, references, maxOrder, smooth, refLenMethod: this.refLenMethod });
             
             // Data is already in the correct format for the WebAssembly function
             const referencesArray = references;
             const predictionsArray = predictions;
             
-            console.log('🔧 Formatted data:', { referencesArray, predictionsArray, maxOrder, smooth });
+            console.log('🔧 Formatted data:', { referencesArray, predictionsArray, maxOrder, smooth, refLenMethod: this.refLenMethod });
             
             // Call the WebAssembly function
-            const result = compute_score(referencesArray, predictionsArray, maxOrder, smooth, 'shortest');
+            const result = compute_score(referencesArray, predictionsArray, maxOrder, smooth, this.refLenMethod);
             
             console.log('✅ BLEU calculation successful:', result);
             
@@ -338,4 +350,16 @@ class BleuScoreApp {
             this.hideLoading();
         }
     }
-} 
+}
+
+function startApp() {
+    initWasm();
+    new BleuScoreApp();
+}
+
+// Wait for DOM to be ready, accounting for async WebAssembly module loading.
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startApp);
+} else {
+    startApp();
+}

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -37,6 +37,16 @@
             --ring: 16 85% 45%;
             --radius: 0.5rem;
         }
+
+        body[data-ref-len-method="shortest"] {
+            --primary: 16 85% 45%;
+            --ring: 16 85% 45%;
+        }
+
+        body[data-ref-len-method="closest"] {
+            --primary: 202 83% 42%;
+            --ring: 202 83% 42%;
+        }
         
         * {
             border-color: hsl(var(--border));
@@ -212,6 +222,115 @@
             border-radius: 0.25rem;
             border: 1px solid hsl(var(--primary));
             background-color: hsl(var(--background));
+        }
+
+        .mode-control {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .mode-switch {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.25rem;
+            padding: 0.25rem;
+            border: 1px solid hsl(var(--border));
+            border-radius: calc(var(--radius) - 2px);
+            background-color: hsl(var(--muted));
+            width: 100%;
+        }
+
+        .mode-option {
+            height: 2rem;
+            border: 0;
+            border-radius: calc(var(--radius) - 4px);
+            background: transparent;
+            color: hsl(var(--muted-foreground));
+            cursor: pointer;
+            font-size: 0.75rem;
+            font-weight: 600;
+            transition: all 0.2s ease-in-out;
+            white-space: nowrap;
+        }
+
+        .mode-option:hover {
+            color: hsl(var(--foreground));
+            background-color: hsl(var(--background) / 0.7);
+        }
+
+        .mode-option.is-active {
+            background-color: hsl(var(--primary));
+            color: hsl(var(--primary-foreground));
+            box-shadow: 0 1px 2px -1px rgb(0 0 0 / 0.2);
+        }
+
+        .help-wrap {
+            position: relative;
+            flex: 0 0 auto;
+        }
+
+        .help-button {
+            width: 2rem;
+            height: 2rem;
+            border-radius: 9999px;
+            border: 1px solid hsl(var(--border));
+            background-color: hsl(var(--background));
+            color: hsl(var(--muted-foreground));
+            cursor: help;
+            font-size: 0.8rem;
+            font-weight: 700;
+            line-height: 1;
+            transition: all 0.2s ease-in-out;
+        }
+
+        .help-button:hover,
+        .help-button:focus-visible {
+            border-color: hsl(var(--primary));
+            color: hsl(var(--primary));
+            outline: none;
+        }
+
+        .help-tooltip {
+            position: absolute;
+            right: 0;
+            top: calc(100% + 0.5rem);
+            z-index: 20;
+            width: min(22rem, calc(100vw - 2rem));
+            border: 1px solid hsl(var(--border));
+            border-radius: var(--radius);
+            background-color: hsl(var(--popover));
+            color: hsl(var(--popover-foreground));
+            box-shadow: 0 10px 24px -12px rgb(0 0 0 / 0.35);
+            padding: 0.75rem;
+            opacity: 0;
+            transform: translateY(-0.25rem);
+            pointer-events: none;
+            transition: opacity 0.16s ease-in-out, transform 0.16s ease-in-out;
+        }
+
+        .help-wrap:hover .help-tooltip,
+        .help-wrap:focus-within .help-tooltip {
+            opacity: 1;
+            transform: translateY(0);
+            pointer-events: auto;
+        }
+
+        .help-title {
+            font-size: 0.75rem;
+            font-weight: 700;
+            margin-bottom: 0.35rem;
+        }
+
+        .help-copy {
+            font-size: 0.72rem;
+            color: hsl(var(--muted-foreground));
+            line-height: 1.4;
+        }
+
+        .help-copy strong {
+            color: hsl(var(--foreground));
+            font-weight: 700;
         }
         
         .badge {
@@ -552,7 +671,7 @@
         }
     </style>
 </head>
-<body>
+<body data-ref-len-method="shortest">
     <!-- Hero Section -->
     <div class="hero-section">
         <div class="max-w-6xl mx-auto px-4">
@@ -640,6 +759,28 @@
                                     <div class="flex items-center space-x-2 pt-1">
                                         <input type="checkbox" id="smoothing" class="checkbox">
                                         <label for="smoothing" class="text-sm">Enable smoothing</label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="mt-3 space-y-1">
+                                <div class="flex items-center justify-between gap-2">
+                                    <label class="label mb-0">Reference Length Mode</label>
+                                    <div class="help-wrap">
+                                        <button type="button" class="help-button" aria-label="Reference length mode help">?</button>
+                                        <div class="help-tooltip" role="tooltip">
+                                            <div class="help-title">Reference length mode</div>
+                                            <div class="help-copy">
+                                                <strong>Shortest</strong> uses the shortest reference for brevity penalty and matches HuggingFace evaluate / TF NMT behavior.<br><br>
+                                                <strong>Closest</strong> uses the reference length closest to each prediction, with shorter winning ties, matching SacreBLEU / NIST mteval-v13a.
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="mode-control">
+                                    <div class="mode-switch" role="group" aria-label="Reference length mode">
+                                        <button type="button" class="mode-option is-active" data-ref-len-method="shortest" aria-pressed="true">Shortest</button>
+                                        <button type="button" class="mode-option" data-ref-len-method="closest" aria-pressed="false">Closest</button>
                                     </div>
                                 </div>
                             </div>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -228,35 +228,55 @@
             display: flex;
             align-items: center;
             gap: 0.5rem;
+            min-width: 0;
         }
 
         .mode-switch {
             display: grid;
             grid-template-columns: repeat(2, minmax(0, 1fr));
-            gap: 0.25rem;
-            padding: 0.25rem;
+            gap: 0.2rem;
+            padding: 0.2rem;
             border: 1px solid hsl(var(--border));
             border-radius: calc(var(--radius) - 2px);
-            background-color: hsl(var(--muted));
-            width: min(16rem, 100%);
+            background-color: hsl(var(--background));
+            width: min(20rem, 100%);
+            box-shadow: inset 0 1px 2px rgb(0 0 0 / 0.04);
         }
 
         .mode-option {
-            height: 2rem;
+            height: 2.15rem;
             border: 0;
             border-radius: calc(var(--radius) - 4px);
             background: transparent;
             color: hsl(var(--muted-foreground));
             cursor: pointer;
-            font-size: 0.75rem;
-            font-weight: 600;
+            font: inherit;
             transition: all 0.2s ease-in-out;
             white-space: nowrap;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.3rem;
+            padding: 0 0.4rem;
+        }
+
+        .mode-name {
+            font-size: 0.76rem;
+            font-weight: 700;
+        }
+
+        .mode-source {
+            border-radius: 9999px;
+            background-color: hsl(var(--muted));
+            color: hsl(var(--muted-foreground));
+            padding: 0.08rem 0.3rem;
+            font-size: 0.6rem;
+            font-weight: 700;
         }
 
         .mode-option:hover {
             color: hsl(var(--foreground));
-            background-color: hsl(var(--background) / 0.7);
+            background-color: hsl(var(--muted) / 0.7);
         }
 
         .mode-option.is-active {
@@ -265,14 +285,19 @@
             box-shadow: 0 1px 2px -1px rgb(0 0 0 / 0.2);
         }
 
+        .mode-option.is-active .mode-source {
+            background-color: hsl(var(--primary-foreground) / 0.18);
+            color: hsl(var(--primary-foreground));
+        }
+
         .help-wrap {
             position: relative;
             flex: 0 0 auto;
         }
 
         .help-button {
-            width: 2rem;
-            height: 2rem;
+            width: 2.15rem;
+            height: 2.15rem;
             border-radius: 9999px;
             border: 1px solid hsl(var(--border));
             background-color: hsl(var(--background));
@@ -335,14 +360,14 @@
 
         .config-bar {
             border-bottom: 1px solid hsl(var(--border));
-            background-color: hsl(var(--card));
+            background-color: hsl(var(--muted) / 0.45);
         }
 
         .config-panel {
             display: flex;
             align-items: center;
-            gap: 0.75rem;
-            padding: 0.75rem 0;
+            gap: 0.5rem;
+            padding: 0.6rem 0;
             overflow-x: auto;
             white-space: nowrap;
         }
@@ -350,14 +375,24 @@
         .config-group {
             display: flex;
             align-items: center;
-            gap: 0.5rem;
-            min-height: 2.25rem;
+            gap: 0.45rem;
+            min-height: 2.75rem;
+            border: 1px solid hsl(var(--border));
+            border-radius: var(--radius);
+            background-color: hsl(var(--background));
+            padding: 0.35rem 0.45rem;
+            box-shadow: 0 1px 2px -1px rgb(0 0 0 / 0.08);
         }
 
         .config-label {
             margin: 0;
             white-space: nowrap;
             color: hsl(var(--muted-foreground));
+            font-size: 0.68rem;
+            font-weight: 700;
+            max-width: 5.5rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .config-ngram {
@@ -374,14 +409,16 @@
         }
 
         .config-mode {
-            flex: 1 0 24rem;
-            min-width: 24rem;
+            flex: 1 0 30rem;
+            min-width: 30rem;
         }
 
         .config-action {
             margin-left: auto;
             min-width: 12rem;
             flex: 0 0 auto;
+            height: 2.75rem;
+            box-shadow: 0 6px 14px -10px hsl(var(--primary));
         }
         
         .badge {
@@ -792,8 +829,14 @@
                         <label class="label config-label">Reference Length Mode</label>
                         <div class="mode-control">
                             <div class="mode-switch" role="group" aria-label="Reference length mode">
-                                <button type="button" class="mode-option is-active" data-ref-len-method="shortest" aria-pressed="true">Shortest</button>
-                                <button type="button" class="mode-option" data-ref-len-method="closest" aria-pressed="false">Closest</button>
+                                <button type="button" class="mode-option is-active" data-ref-len-method="shortest" aria-pressed="true">
+                                    <span class="mode-name">Shortest</span>
+                                    <span class="mode-source">HuggingFace</span>
+                                </button>
+                                <button type="button" class="mode-option" data-ref-len-method="closest" aria-pressed="false">
+                                    <span class="mode-name">Closest</span>
+                                    <span class="mode-source">SacreBLEU</span>
+                                </button>
                             </div>
                             <div class="help-wrap">
                                 <button type="button" class="help-button" aria-label="Reference length mode help">?</button>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -238,7 +238,7 @@
             border: 1px solid hsl(var(--border));
             border-radius: calc(var(--radius) - 2px);
             background-color: hsl(var(--muted));
-            width: 100%;
+            width: min(16rem, 100%);
         }
 
         .mode-option {
@@ -332,6 +332,57 @@
             color: hsl(var(--foreground));
             font-weight: 700;
         }
+
+        .config-bar {
+            border-bottom: 1px solid hsl(var(--border));
+            background-color: hsl(var(--card));
+        }
+
+        .config-panel {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.75rem 0;
+            overflow-x: auto;
+            white-space: nowrap;
+        }
+
+        .config-group {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            min-height: 2.25rem;
+        }
+
+        .config-label {
+            margin: 0;
+            white-space: nowrap;
+            color: hsl(var(--muted-foreground));
+        }
+
+        .config-ngram {
+            width: 4.75rem;
+            flex: 0 0 auto;
+        }
+
+        .config-smoothing {
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            font-size: 0.8rem;
+            white-space: nowrap;
+        }
+
+        .config-mode {
+            flex: 1 0 24rem;
+            min-width: 24rem;
+        }
+
+        .config-action {
+            margin-left: auto;
+            min-width: 12rem;
+            flex: 0 0 auto;
+        }
         
         .badge {
             display: inline-flex;
@@ -368,7 +419,7 @@
             border: 2px solid hsl(var(--border));
             border-radius: var(--radius);
             background-color: hsl(var(--background));
-            padding: 0.75rem;
+            padding: 0.625rem;
             margin-bottom: 0.5rem;
             transition: all 0.2s ease-in-out;
             box-shadow: 0 1px 2px -1px rgb(0 0 0 / 0.1);
@@ -402,7 +453,7 @@
             border-radius: var(--radius);
             background-color: hsl(var(--primary) / 0.03);
             color: hsl(var(--primary));
-            padding: 1rem;
+            padding: 0.625rem;
             width: 100%;
             transition: all 0.2s ease-in-out;
             cursor: pointer;
@@ -452,7 +503,7 @@
         
         .score-display {
             text-align: center;
-            padding: 1.5rem;
+            padding: 1rem;
         }
         
         .score-number {
@@ -496,8 +547,8 @@
         
         .sticky-sidebar {
             position: sticky;
-            top: 1rem;
-            max-height: calc(100vh - 2rem);
+            top: 0.75rem;
+            max-height: calc(100vh - 1.5rem);
             overflow-y: auto;
         }
         
@@ -601,6 +652,15 @@
                 font-size: 0.65rem;
                 padding: 0.25rem 0.35rem;
                 gap: 0.25rem;
+            }
+
+            .config-panel {
+                align-items: center;
+                gap: 0.5rem;
+            }
+
+            .config-action {
+                margin-left: 0;
             }
         }
 
@@ -712,8 +772,54 @@
 
     <!-- Main Content -->
     <main class="main-content">
-        <div class="max-w-6xl mx-auto px-4 py-6">
-            <div class="grid lg:grid-cols-2 gap-8">
+        <section class="config-bar">
+            <div class="max-w-6xl mx-auto px-4">
+                <div class="config-panel" aria-label="Configuration">
+                    <div class="config-group">
+                        <label for="ngram" class="label config-label">N-gram Order</label>
+                        <input type="number" id="ngram" class="input config-ngram" value="4" min="1" max="10">
+                    </div>
+
+                    <div class="config-group">
+                        <label class="label config-label">Smoothing</label>
+                        <div class="config-smoothing">
+                            <input type="checkbox" id="smoothing" class="checkbox">
+                            <label for="smoothing">Enable</label>
+                        </div>
+                    </div>
+
+                    <div class="config-group config-mode">
+                        <label class="label config-label">Reference Length Mode</label>
+                        <div class="mode-control">
+                            <div class="mode-switch" role="group" aria-label="Reference length mode">
+                                <button type="button" class="mode-option is-active" data-ref-len-method="shortest" aria-pressed="true">Shortest</button>
+                                <button type="button" class="mode-option" data-ref-len-method="closest" aria-pressed="false">Closest</button>
+                            </div>
+                            <div class="help-wrap">
+                                <button type="button" class="help-button" aria-label="Reference length mode help">?</button>
+                                <div class="help-tooltip" role="tooltip">
+                                    <div class="help-title">Reference length mode</div>
+                                    <div class="help-copy">
+                                        <strong>Shortest</strong> uses the shortest reference for brevity penalty and matches HuggingFace evaluate / TF NMT behavior.<br><br>
+                                        <strong>Closest</strong> uses the reference length closest to each prediction, with shorter winning ties, matching SacreBLEU / NIST mteval-v13a.
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <button id="calculate-btn" class="btn btn-primary config-action">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
+                            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path>
+                        </svg>
+                        Calculate BLEU Score
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <div class="max-w-6xl mx-auto px-4 py-3">
+            <div class="grid lg:grid-cols-2 gap-4">
                 <!-- Left Side: Input Area -->
                 <div class="space-y-4">
                     <!-- Predictions & References -->
@@ -735,63 +841,6 @@
                                     <line x1="5" y1="12" x2="19" y2="12"></line>
                                 </svg>
                                 Add Prediction
-                            </button>
-                        </div>
-                    </div>
-
-                    <!-- Settings -->
-                    <div class="card">
-                        <div class="card-header">
-                            <h2 class="card-title">Configuration</h2>
-                            <p class="card-description">
-                                Adjust the BLEU score calculation parameters.
-                            </p>
-                        </div>
-                        <div class="card-content">
-                            <div class="grid grid-cols-2 gap-3">
-                                <div class="space-y-1">
-                                    <label for="ngram" class="label">N-gram Order</label>
-                                    <input type="number" id="ngram" class="input" value="4" min="1" max="10">
-                                </div>
-                                
-                                <div class="space-y-1">
-                                    <label class="label">Smoothing</label>
-                                    <div class="flex items-center space-x-2 pt-1">
-                                        <input type="checkbox" id="smoothing" class="checkbox">
-                                        <label for="smoothing" class="text-sm">Enable smoothing</label>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="mt-3 space-y-1">
-                                <div class="flex items-center justify-between gap-2">
-                                    <label class="label mb-0">Reference Length Mode</label>
-                                    <div class="help-wrap">
-                                        <button type="button" class="help-button" aria-label="Reference length mode help">?</button>
-                                        <div class="help-tooltip" role="tooltip">
-                                            <div class="help-title">Reference length mode</div>
-                                            <div class="help-copy">
-                                                <strong>Shortest</strong> uses the shortest reference for brevity penalty and matches HuggingFace evaluate / TF NMT behavior.<br><br>
-                                                <strong>Closest</strong> uses the reference length closest to each prediction, with shorter winning ties, matching SacreBLEU / NIST mteval-v13a.
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="mode-control">
-                                    <div class="mode-switch" role="group" aria-label="Reference length mode">
-                                        <button type="button" class="mode-option is-active" data-ref-len-method="shortest" aria-pressed="true">Shortest</button>
-                                        <button type="button" class="mode-option" data-ref-len-method="closest" aria-pressed="false">Closest</button>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <div class="section-divider"></div>
-                            
-                            <button id="calculate-btn" class="btn btn-primary w-full">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2">
-                                    <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path>
-                                </svg>
-                                Calculate BLEU Score
                             </button>
                         </div>
                     </div>

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,10 +8,8 @@
       "name": "bleuscore-webapp",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "bleuscore-js": "^0.1.5"
-      },
       "devDependencies": {
+        "@wasm-tool/wasm-pack-plugin": "^1.7.0",
         "html-webpack-plugin": "^5.5.0",
         "webpack": "^5.106.2",
         "webpack-cli": "^5.1.0",
@@ -398,6 +396,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@wasm-tool/wasm-pack-plugin": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@wasm-tool/wasm-pack-plugin/-/wasm-pack-plugin-1.7.0.tgz",
+      "integrity": "sha512-WikzYsw7nTd5CZxH75h7NxM/FLJAgqfWt+/gk3EL3wYKxiIlpMIYPja+sHQl3ARiicIYy4BDfxkbAVjRYlouTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "command-exists": "^1.2.7",
+        "watchpack": "^2.1.1",
+        "which": "^2.0.2"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -741,6 +752,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -794,12 +818,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/bleuscore-js": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bleuscore-js/-/bleuscore-js-0.1.5.tgz",
-      "integrity": "sha512-oUKMJXCGN5YwIXXkhRJfBDbJ8R7d7SIGuJxRuK08eXoIBbuNMyKSHKHIJEXzbNjkDg0xM7j2omf+KBlacGXQVw==",
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -987,6 +1005,44 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1063,10 +1119,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1520,6 +1600,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,10 +22,9 @@
     "type": "git",
     "url": "https://github.com/shenxiangzhuang/bleuscore.git"
   },
-  "dependencies": {
-    "bleuscore-js": "^0.1.5"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@wasm-tool/wasm-pack-plugin": "^1.7.0",
     "html-webpack-plugin": "^5.5.0",
     "webpack": "^5.106.2",
     "webpack-cli": "^5.1.0",

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -1,11 +1,20 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const WasmPackPlugin = require('@wasm-tool/wasm-pack-plugin');
+
+const getrandomWasmBackendFlag = '--cfg getrandom_backend="wasm_js"';
+if (!process.env.RUSTFLAGS?.includes('getrandom_backend="wasm_js"')) {
+    process.env.RUSTFLAGS = [process.env.RUSTFLAGS, getrandomWasmBackendFlag]
+        .filter(Boolean)
+        .join(' ');
+}
 
 module.exports = (env, argv) => {
     const isProduction = argv.mode === 'production';
     
     return {
         mode: isProduction ? 'production' : 'development',
+        target: ['web', 'es2020'],
         entry: './app.js',
         output: {
             path: path.resolve(__dirname, 'dist'),
@@ -13,7 +22,18 @@ module.exports = (env, argv) => {
             clean: true,
             publicPath: isProduction ? '/bleuscore/' : '/',
         },
+        resolve: {
+            alias: {
+                'bleuscore-js': path.resolve(__dirname, '../bindings/js/pkg'),
+            },
+        },
         devServer: {
+            client: {
+                overlay: {
+                    errors: true,
+                    warnings: false,
+                },
+            },
             static: {
                 directory: path.join(__dirname),
             },
@@ -25,6 +45,9 @@ module.exports = (env, argv) => {
             },
         },
         plugins: [
+            new WasmPackPlugin({
+                crateDirectory: path.resolve(__dirname, '../bindings/js'),
+            }),
             new HtmlWebpackPlugin({
                 template: './index.html',
                 filename: 'index.html',
@@ -32,7 +55,7 @@ module.exports = (env, argv) => {
         ],
         experiments: {
             topLevelAwait: true,
-            // asyncWebAssembly: true,
+            asyncWebAssembly: true,
         },
         optimization: {
             splitChunks: isProduction ? {


### PR DESCRIPTION
## Summary

Closes #30

Investigates and resolves the BLEU score discrepancy between HuggingFace `evaluate` and SacreBLEU by exposing the underlying **reference length policy** as a configurable parameter.

## Root Cause

The difference comes from how each library selects the reference length for brevity penalty calculation:
- **HuggingFace**: uses the **shortest** reference length
- **SacreBLEU**: uses the **closest** reference length (closest to the hypothesis length)

For the default example, this results in `ref_len=6` (Shortest) vs `ref_len=7` (Closest), producing different BLEU scores.

## Changes

### Rust Core (`crates/bleuscore`)
- Added `RefLenMethod` enum with `Shortest` and `Closest` variants
- Added `closest_ref_len` helper function
- Updated `compute_score` to accept `ref_len_method: RefLenMethod` parameter

### Python Binding (`bindings/python`)
- Added `ref_len_method: str = "shortest"` parameter to `compute_score`
- Supports aliases: `"hf"`, `"huggingface"` → Shortest; `"sacrebleu"`, `"closest"` → Closest
- Added 13 property/compatibility tests verifying parity with HuggingFace and SacreBLEU

### JS/WASM Binding (`bindings/js`)
- Updated `compute_score` to 5-arg API accepting `ref_len_method` string

### Webapp (`webapp`)
- Integrated local WASM build (instead of published npm package) to use the new API
- Added **Reference Length Mode** toggle in the configuration bar
  - **Shortest** (HuggingFace) — orange theme
  - **Closest** (SacreBLEU) — blue theme
- Added help tooltip explaining the difference between modes
- Flat configuration layout for better UX

## Testing

All existing tests pass. New tests added for Python binding compatibility verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reference-length method selection for BLEU computation (shortest, closest, hf, sacrebleu)
  * Web app includes a mode selector to switch between reference-length methods
  * JavaScript and Python libraries now support the reference-length method parameter

* **Tests**
  * Added SacreBLEU compatibility verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->