### PR TITLE
ci: add hyperfine benchmark workflow for PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,71 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: Run hyperfine benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist --find-interpreter --manifest-path bindings/python/Cargo.toml
+          manylinux: auto
+
+      - name: Install bleuscore and benchmark deps
+        run: |
+          pip install bleuscore --no-index --find-links dist --force-reinstall
+          pip install sacrebleu
+
+      - name: Install hyperfine
+        run: |
+          wget -q https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine_1.18.0_amd64.deb
+          sudo dpkg -i hyperfine_1.18.0_amd64.deb
+
+      - name: Run benchmarks
+        working-directory: benchmark
+        run: |
+          hyperfine \
+            --warmup 1 \
+            --runs 3 \
+            --export-markdown result.md \
+            --export-json result.json \
+            "python simple/rs_bleuscore.py 1000" \
+            "python simple/local_hf_bleu.py 1000" \
+            "python simple/rs_bleuscore.py 10000" \
+            "python simple/local_hf_bleu.py 10000" \
+            "python simple/rs_bleuscore.py 100000" \
+            "python simple/local_hf_bleu.py 100000"
+
+      - name: Read benchmark results
+        id: bench
+        run: |
+          {
+            echo 'RESULT<<EOF'
+            cat benchmark/result.md
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-tag: hyperfine-benchmark
+          body: |
+            ## Benchmark Results (hyperfine)
+
+            ${{ steps.bench.outputs.RESULT }}
+
+            > `bleuscore` vs `local_hf_bleu` · ${{ runner.os }} · [run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,23 +37,22 @@ jobs:
       - name: Run benchmarks
         working-directory: benchmark
         run: |
-          # Run each size as an independent group; local_hf_bleu is the baseline
+          # Run each size as an independent hyperfine group
           for N in 1000 10000 100000; do
             hyperfine \
               --warmup 1 \
               --runs 3 \
-              --reference "python simple/local_hf_bleu.py $N" \
               --export-markdown "result_${N}.md" \
               "python simple/rs_bleuscore.py $N" \
               "python simple/local_hf_bleu.py $N"
           done
 
-          # Merge all per-size tables into one markdown file
-          echo '| N | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |' > result.md
-          echo '|---:|:---|---:|---:|---:|---:|' >> result.md
+          # Merge per-size tables with size headers
+          > result.md
           for N in 1000 10000 100000; do
-            # Strip the header rows and append data rows, prefixing with N
-            tail -n +3 "result_${N}.md" | grep -v '^$' | sed "s/^| /| ${N} | /" >> result.md
+            echo "### N = ${N}" >> result.md
+            cat "result_${N}.md" >> result.md
+            echo >> result.md
           done
 
       - name: Read benchmark results
@@ -73,7 +72,7 @@ jobs:
           body: |
             ## Benchmark Results (hyperfine)
 
-            > Baseline: `local_hf_bleu` — relative values show how many times faster/slower `rs_bleuscore` is.
+            > Each size is a separate group. `Relative` is normalized to the fastest command in that group (`rs_bleuscore`); `local_hf_bleu` shows how many times slower it is.
 
             ${{ steps.bench.outputs.RESULT }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,17 +37,24 @@ jobs:
       - name: Run benchmarks
         working-directory: benchmark
         run: |
-          hyperfine \
-            --warmup 1 \
-            --runs 3 \
-            --export-markdown result.md \
-            --export-json result.json \
-            "python simple/rs_bleuscore.py 1000" \
-            "python simple/local_hf_bleu.py 1000" \
-            "python simple/rs_bleuscore.py 10000" \
-            "python simple/local_hf_bleu.py 10000" \
-            "python simple/rs_bleuscore.py 100000" \
-            "python simple/local_hf_bleu.py 100000"
+          # Run each size as an independent group; local_hf_bleu is the baseline
+          for N in 1000 10000 100000; do
+            hyperfine \
+              --warmup 1 \
+              --runs 3 \
+              --reference "python simple/local_hf_bleu.py $N" \
+              --export-markdown "result_${N}.md" \
+              "python simple/rs_bleuscore.py $N" \
+              "python simple/local_hf_bleu.py $N"
+          done
+
+          # Merge all per-size tables into one markdown file
+          echo '| N | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |' > result.md
+          echo '|---:|:---|---:|---:|---:|---:|' >> result.md
+          for N in 1000 10000 100000; do
+            # Strip the header rows and append data rows, prefixing with N
+            tail -n +3 "result_${N}.md" | grep -v '^$' | sed "s/^| /| ${N} | /" >> result.md
+          done
 
       - name: Read benchmark results
         id: bench
@@ -65,6 +72,8 @@ jobs:
           comment-tag: hyperfine-benchmark
           body: |
             ## Benchmark Results (hyperfine)
+
+            > Baseline: `local_hf_bleu` — relative values show how many times faster/slower `rs_bleuscore` is.
 
             ${{ steps.bench.outputs.RESULT }}
 

--- a/README.md
+++ b/README.md
@@ -59,64 +59,7 @@ print(results)
 
 We use the demo data shown in quick start to do this simple benchmark.
 You can check the [benchmark/simple](./benchmark/simple) for the benchmark source code.
-
-- `rs_bleuscore`: bleuscore python library
-- `local_hf_bleu`: huggingface evaluate bleu algorithm in **local**
-- `sacre_bleu`: sacrebleu
-  - Note that we got different result with sacrebleu in the simple demo data and all the rests have same result
-- `hf_evaluate`: huggingface evaluate bleu algorithm with **evaluate** package
-
-
-The `N` is used to enlarge the predictions/references size by simply duplication the demo data as shown before.
-We can see that as `N` increase, the bleuscore gets better performance.
-You can navigate [benchmark](./benchmark/README.md) for more benchmark details.
-
-
-
-### N=100
-
-```bash
-hyperfine --warmup 5 --runs 10   \
-  "python simple/rs_bleuscore.py 100" \
-  "python simple/local_hf_bleu.py 100" \
-  "python simple/sacre_bleu.py 100"   \
-  "python simple/hf_evaluate.py 100"
-
-Benchmark 1: python simple/rs_bleuscore.py 100
-  Time (mean ± σ):      19.0 ms ±   2.6 ms    [User: 17.8 ms, System: 5.3 ms]
-  Range (min … max):    14.8 ms …  23.2 ms    10 runs
-
-Benchmark 2: python simple/local_hf_bleu.py 100
-  Time (mean ± σ):      21.5 ms ±   2.2 ms    [User: 19.0 ms, System: 2.5 ms]
-  Range (min … max):    16.8 ms …  24.1 ms    10 runs
-
-Benchmark 3: python simple/sacre_bleu.py 100
-  Time (mean ± σ):      45.9 ms ±   2.2 ms    [User: 38.7 ms, System: 7.1 ms]
-  Range (min … max):    43.5 ms …  50.9 ms    10 runs
-
-Benchmark 4: python simple/hf_evaluate.py 100
-  Time (mean ± σ):      4.504 s ±  0.429 s    [User: 0.762 s, System: 0.823 s]
-  Range (min … max):    4.163 s …  5.446 s    10 runs
-
-Summary
-  python simple/rs_bleuscore.py 100 ran
-    1.13 ± 0.20 times faster than python simple/local_hf_bleu.py 100
-    2.42 ± 0.35 times faster than python simple/sacre_bleu.py 100
-  237.68 ± 39.88 times faster than python simple/hf_evaluate.py 100
-```
-
-### N = 1K ~ 1M
-
-| Command                                  |       Mean [ms] | Min [ms] | Max [ms] |        Relative |
-|:-----------------------------------------|----------------:|---------:|---------:|----------------:|
-| `python simple/rs_bleuscore.py 1000`     |      20.3 ± 1.3 |     18.2 |     21.4 |            1.00 |
-| `python simple/local_hf_bleu.py 1000`    |      45.8 ± 1.2 |     44.2 |     47.5 |     2.26 ± 0.16 |
-| `python simple/rs_bleuscore.py 10000`    |      37.8 ± 1.5 |     35.9 |     39.5 |     1.87 ± 0.14 |
-| `python simple/local_hf_bleu.py 10000`   |     295.0 ± 5.9 |    288.6 |    304.2 |    14.55 ± 0.98 |
-| `python simple/rs_bleuscore.py 100000`   |     219.6 ± 3.3 |    215.3 |    224.0 |    10.83 ± 0.72 |
-| `python simple/local_hf_bleu.py 100000`  |   2781.4 ± 42.2 |   2723.1 |   2833.0 |   137.13 ± 9.10 |
-| `python simple/rs_bleuscore.py 1000000`  |   2048.8 ± 31.4 |   2013.2 |   2090.3 |   101.01 ± 6.71 |
-| `python simple/local_hf_bleu.py 1000000` | 28285.3 ± 100.9 |  28182.1 |  28396.1 | 1394.51 ± 90.21 |
+Detailed per-PR results are tracked automatically via the [Benchmark workflow](.github/workflows/benchmark.yml).
 
 
 


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs hyperfine benchmarks on every PR targeting master.

**What it does:**
- Builds the `bleuscore` Python wheel (release mode via maturin)
- Installs hyperfine and runs `rs_bleuscore` vs `local_hf_bleu` across N=1K, 10K, 100K
- Posts (or updates) a sticky comment on the PR with the markdown benchmark table

This PR serves as the first test of the workflow itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated performance benchmarking on pull requests with results posted as comments for easy performance impact review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->