### PR TITLE
ci: trigger release workflow on published releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
Change the release workflow trigger from tag push to GitHub Release publication.\n\nThis makes package publishing happen when a GitHub Release is published, instead of immediately when a tag is pushed.